### PR TITLE
Fix #31: Change Edit route to /post/edit/{slug}

### DIFF
--- a/src/Blog.Web/Pages/Post/Edit.cshtml
+++ b/src/Blog.Web/Pages/Post/Edit.cshtml
@@ -1,4 +1,4 @@
-@page "{slug}"
+@page "/post/edit/{slug}"
 @model Blog.Web.Pages.Post.EditModel
 @{
     ViewData["Title"] = "Edit Post";


### PR DESCRIPTION
Fixes Issue #31: Edit blog post does not work

**Changes:**
- Changed Edit.cshtml route from @page "{slug}" to @page "/post/edit/{slug}"
- This fixes the routing conflict with post details page at /post/{slug}
- Users can now edit posts at /post/edit/{slug}

**Testing:**
- Build passes