### PR TITLE
Fix #11: Add missing Email configuration (ApiKey, NewsletterListId)

### DIFF
--- a/src/Blog.Web/appsettings.json
+++ b/src/Blog.Web/appsettings.json
@@ -15,8 +15,9 @@
     },
     "Email": {
         "SenderEmail": "avikeid2007@gmail.com",
-        "SenderName": "Devof.NET"
-    
+        "SenderName": "Devof.NET",
+        "ApiKey": "",
+        "NewsletterListId": ""
     },
     "GoogleAnalytics": {
         "MeasurementId": "G-F5GXX9RB9R"


### PR DESCRIPTION
Fixes Issue #11

The Email section in appsettings.json was missing ApiKey and NewsletterListId fields required by BrevoEmailService, causing email features (verification, password reset, newsletter) to fail.

Configure via environment variables:
- Email__ApiKey
- Email__NewsletterListId