### PR TITLE
Fix: Get correct total count for Tag and Search pagination

### DIFF
--- a/src/Blog.Application/Services/PostService.cs
+++ b/src/Blog.Application/Services/PostService.cs
@@ -83,6 +83,7 @@ public class PostService : IPostService
     public async Task<PagedResult<PostDto>> GetByTagAsync(string tagSlug, int page, int pageSize, string? currentUserId = null, CancellationToken cancellationToken = default)
     {
         var posts = await _unitOfWork.Posts.GetByTagAsync(tagSlug, page, pageSize, cancellationToken);
+        var totalCount = await _unitOfWork.Posts.GetCountByTagAsync(tagSlug, cancellationToken);
         var items = new List<PostDto>();
         foreach (var post in posts)
         {
@@ -92,7 +93,7 @@ public class PostService : IPostService
         return new PagedResult<PostDto>
         {
             Items = items,
-            TotalCount = (page - 1) * pageSize + items.Count, // Approximate using page calc
+            TotalCount = totalCount,
             Page = page,
             PageSize = pageSize
         };
@@ -101,6 +102,7 @@ public class PostService : IPostService
     public async Task<PagedResult<PostDto>> SearchAsync(string query, int page, int pageSize, string? currentUserId = null, CancellationToken cancellationToken = default)
     {
         var posts = await _unitOfWork.Posts.SearchAsync(query, page, pageSize, cancellationToken);
+        var totalCount = await _unitOfWork.Posts.GetSearchCountAsync(query, cancellationToken);
         var items = new List<PostDto>();
         foreach (var post in posts)
         {
@@ -110,7 +112,7 @@ public class PostService : IPostService
         return new PagedResult<PostDto>
         {
             Items = items,
-            TotalCount = page == 1 ? items.Count : (page - 1) * pageSize + items.Count,
+            TotalCount = totalCount,
             Page = page,
             PageSize = pageSize
         };

--- a/src/Blog.Domain/Interfaces/IRepositories.cs
+++ b/src/Blog.Domain/Interfaces/IRepositories.cs
@@ -11,9 +11,11 @@ public interface IPostRepository
     Task<IEnumerable<Post>> GetByAuthorIdAsync(string authorId, int page, int pageSize, PostStatus? status = null, CancellationToken cancellationToken = default);
     Task<int> GetCountByAuthorIdAsync(string authorId, PostStatus? status = null, CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> GetByTagAsync(string tagSlug, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<int> GetCountByTagAsync(string tagSlug, CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> GetRelatedByTagsAsync(int postId, IEnumerable<int> tagIds, int count, CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> GetTrendingAsync(int count, CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> SearchAsync(string query, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<int> GetSearchCountAsync(string query, CancellationToken cancellationToken = default);
     Task<int> GetTotalCountAsync(CancellationToken cancellationToken = default);
     Task<int> CountPublishedAsync(CancellationToken cancellationToken = default);
     Task<Post> AddAsync(Post post, CancellationToken cancellationToken = default);

--- a/src/Blog.Infrastructure/Repositories/Repositories.cs
+++ b/src/Blog.Infrastructure/Repositories/Repositories.cs
@@ -89,6 +89,13 @@ public class PostRepository : IPostRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<int> GetCountByTagAsync(string tagSlug, CancellationToken cancellationToken = default)
+    {
+        return await _context.Posts
+            .Where(p => p.Status == PostStatus.Published && p.PostTags.Any(pt => pt.Tag.Slug == tagSlug))
+            .CountAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<Post>> GetRelatedByTagsAsync(int postId, IEnumerable<int> tagIds, int count, CancellationToken cancellationToken = default)
     {
         return await _context.Posts
@@ -127,6 +134,16 @@ public class PostRepository : IPostRepository
             .Skip((page - 1) * pageSize)
             .Take(pageSize)
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> GetSearchCountAsync(string query, CancellationToken cancellationToken = default)
+    {
+        var searchQuery = $"%{query}%";
+        return await _context.Posts
+            .Where(p => p.Status == PostStatus.Published &&
+                       (EF.Functions.Like(p.Title, searchQuery) ||
+                        EF.Functions.Like(p.Content, searchQuery)))
+            .CountAsync(cancellationToken);
     }
 
     public async Task<int> GetTotalCountAsync(CancellationToken cancellationToken = default)

--- a/src/Blog.Web/appsettings.json
+++ b/src/Blog.Web/appsettings.json
@@ -15,8 +15,9 @@
     },
     "Email": {
         "SenderEmail": "avikeid2007@gmail.com",
-        "SenderName": "Devof.NET"
-    
+        "SenderName": "Devof.NET",
+        "ApiKey": "",
+        "NewsletterListId": ""
     },
     "GoogleAnalytics": {
         "MeasurementId": "G-F5GXX9RB9R"


### PR DESCRIPTION
## Summary

Fixed pagination bug where Tag and Search pages showed incorrect TotalCount values.

## Changes

- Added `GetCountByTagAsync()` method to IPostRepository and PostRepository
- Added `GetSearchCountAsync()` method to IPostRepository and PostRepository  
- Updated `PostService.GetByTagAsync()` to use actual count from database
- Updated `PostService.SearchAsync()` to use actual count from database

## Root Cause

The original code calculating TotalCount using formula `(page - 1) * pageSize + items.Count` is incorrect.

## Fix

Now queries database for actual count instead of estimating.
