### PR TITLE
Fix #15: Implement GDPR double opt-in for newsletter

### DIFF
--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -190,7 +190,7 @@ public class NewsletterController : ControllerBase
 
         try
         {
-            await _emailService.SendEmailAsync(subscriber.Email, subject, body);
+            await _emailService.SendNotificationEmailAsync(subscriber.Email, subject, body);
             _logger.LogInformation("Confirmation email sent to: {Email}", subscriber.Email);
         }
         catch (Exception ex)

--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -1,4 +1,5 @@
 using Blog.Domain.Entities;
+using Blog.Application.Services;
 using Blog.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -13,11 +14,13 @@ public class NewsletterController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
     private readonly ILogger<NewsletterController> _logger;
+    private readonly IEmailService _emailService;
 
-    public NewsletterController(ApplicationDbContext context, ILogger<NewsletterController> logger)
+    public NewsletterController(ApplicationDbContext context, ILogger<NewsletterController> logger, IEmailService emailService)
     {
         _context = context;
         _logger = logger;
+        _emailService = emailService;
     }
 
     [HttpPost("subscribe")]
@@ -50,12 +53,18 @@ public class NewsletterController : ControllerBase
                 }
                 else
                 {
-                    // Reactivate subscription
-                    existing.IsActive = true;
+                    // Re-subscribe requires confirmation again
+                    existing.ConfirmationToken = Guid.NewGuid().ToString("N");
+                    existing.IsActive = false;
+                    existing.IsConfirmed = false;
                     existing.UnsubscribedAt = null;
                     existing.SubscribedAt = DateTime.UtcNow;
                     await _context.SaveChangesAsync();
-                    return Ok(new { success = true, message = "Welcome back! Your subscription has been reactivated." });
+
+                    // Send confirmation email
+                    await SendConfirmationEmailAsync(existing);
+
+                    return Ok(new { success = true, message = "Welcome back! Please check your email to confirm your subscription." });
                 }
             }
 
@@ -65,15 +74,15 @@ public class NewsletterController : ControllerBase
                 Email = email,
                 SubscribedAt = DateTime.UtcNow,
                 ConfirmationToken = Guid.NewGuid().ToString("N"),
-                IsActive = false  // GDPR: require email confirmation before activation
+                IsActive = false,
+                IsConfirmed = false
             };
 
             _context.Subscribers.Add(subscriber);
             await _context.SaveChangesAsync();
 
             // Send confirmation email (GDPR double opt-in)
-            var confirmationLink = Url.Action("ConfirmNewsletter", "Newsletter", new { token = subscriber.ConfirmationToken, email = subscriber.Email }, Request.Scheme);
-            // Note: In production, inject IEmailService and send the confirmation email
+            await SendConfirmationEmailAsync(subscriber);
 
             _logger.LogInformation("New newsletter subscriber (pending confirmation): {Email}", email);
 
@@ -82,6 +91,49 @@ public class NewsletterController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error subscribing email: {Email}", email);
+            return StatusCode(500, new { success = false, message = "Something went wrong. Please try again later." });
+        }
+    }
+
+    [HttpGet("confirm")]
+    public async Task<IActionResult> Confirm([FromQuery] string token, [FromQuery] string email)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(email))
+        {
+            return BadRequest(new { success = false, message = "Invalid confirmation request." });
+        }
+
+        email = email.Trim().ToLowerInvariant();
+
+        try
+        {
+            var subscriber = await _context.Subscribers
+                .FirstOrDefaultAsync(s => s.Email == email && s.ConfirmationToken == token);
+
+            if (subscriber == null)
+            {
+                return BadRequest(new { success = false, message = "Invalid confirmation token." });
+            }
+
+            if (subscriber.IsConfirmed && subscriber.IsActive)
+            {
+                return Ok(new { success = true, message = "You're already confirmed and subscribed!" });
+            }
+
+            // Activate subscription after confirmation
+            subscriber.IsConfirmed = true;
+            subscriber.IsActive = true;
+            subscriber.ConfirmedAt = DateTime.UtcNow;
+            subscriber.ConfirmationToken = null;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Newsletter confirmed: {Email}", email);
+
+            return Ok(new { success = true, message = "Your subscription has been confirmed. Thank you!" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error confirming newsletter: {Email}", email);
             return StatusCode(500, new { success = false, message = "Something went wrong. Please try again later." });
         }
     }
@@ -119,6 +171,32 @@ public class NewsletterController : ControllerBase
         _logger.LogInformation("Newsletter unsubscribe: {Email}", email);
 
         return Ok(new { success = true, message = "You have been unsubscribed successfully." });
+    }
+
+    private async Task SendConfirmationEmailAsync(Subscriber subscriber)
+    {
+        var confirmationLink = Url.Action("Confirm", "ApiNewsletter",
+            new { token = subscriber.ConfirmationToken, email = subscriber.Email },
+            Request.Scheme);
+
+        var subject = "Confirm your newsletter subscription";
+        var body = $@"<html><body>
+<h2>Welcome!</h2>
+<p>Please confirm your newsletter subscription by clicking the link below:</p>
+<p><a href=""{confirmationLink}"">Confirm Subscription</a></p>
+<p>Or copy and paste this link: {confirmationLink}</p>
+<p>If you didn't request this, please ignore this email.</p>
+</body></html>";
+
+        try
+        {
+            await _emailService.SendEmailAsync(subscriber.Email, subject, body);
+            _logger.LogInformation("Confirmation email sent to: {Email}", subscriber.Email);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send confirmation email: {Email}", subscriber.Email);
+        }
     }
 
     private static bool IsValidEmail(string email)


### PR DESCRIPTION
Fixes Issue #15

## Changes
- Inject IEmailService to actually send confirmation emails (was only generated but not sent)
- Add `/api/newsletter/confirm` GET endpoint for token verification  
- Re-confirm on re-subscription
- Track IsConfirmed separately from IsActive

## GDPR Compliance
Users must confirm their email before being added to the newsletter (double opt-in)