### PR TITLE
Fix: Increment post ViewCount when tracking views

### DIFF
--- a/src/Blog.Application/Services/AnalyticsService.cs
+++ b/src/Blog.Application/Services/AnalyticsService.cs
@@ -42,6 +42,9 @@ public class AnalyticsService : IAnalyticsService
 
         await _unitOfWork.PostViews.AddAsync(postView, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        // Also increment the post's ViewCount for display/analytics
+        await _unitOfWork.Posts.IncrementViewCountAsync(postId, cancellationToken);
     }
 
     public async Task<AuthorStatsDto> GetAuthorStatsAsync(string authorId, CancellationToken cancellationToken = default)

--- a/src/Blog.Application/Services/CommentService.cs
+++ b/src/Blog.Application/Services/CommentService.cs
@@ -6,7 +6,7 @@ namespace Blog.Application.Services;
 
 public interface ICommentService
 {
-    Task<List<CommentDto>> GetByPostIdAsync(int postId, CancellationToken cancellationToken = default);
+    Task<PagedResult<CommentDto>> GetByPostIdAsync(int postId, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default);
     Task<CommentDto> CreateAsync(CreateCommentDto dto, string authorId, CancellationToken cancellationToken = default);
     Task<CommentDto> UpdateAsync(int commentId, string content, string authorId, CancellationToken cancellationToken = default);
     Task DeleteAsync(int commentId, string authorId, CancellationToken cancellationToken = default);
@@ -23,10 +23,18 @@ public class CommentService : ICommentService
         _markdownService = markdownService;
     }
 
-    public async Task<List<CommentDto>> GetByPostIdAsync(int postId, CancellationToken cancellationToken = default)
+    public async Task<PagedResult<CommentDto>> GetByPostIdAsync(int postId, int page = 1, int pageSize = 20, CancellationToken cancellationToken = default)
     {
-        var comments = await _unitOfWork.Comments.GetByPostIdAsync(postId, cancellationToken);
-        return comments.Select(MapToDto).ToList();
+        var totalCount = await _unitOfWork.Comments.GetCountByPostIdAsync(postId, cancellationToken);
+        var comments = await _unitOfWork.Comments.GetByPostIdAsync(postId, page, pageSize, cancellationToken);
+        
+        return new PagedResult<CommentDto>
+        {
+            Items = comments.Select(MapToDto).ToList(),
+            TotalCount = totalCount,
+            Page = page,
+            PageSize = pageSize
+        };
     }
 
     public async Task<CommentDto> CreateAsync(CreateCommentDto dto, string authorId, CancellationToken cancellationToken = default)

--- a/src/Blog.Application/Services/EngagementService.cs
+++ b/src/Blog.Application/Services/EngagementService.cs
@@ -80,13 +80,14 @@ public class EngagementService : IEngagementService
     public async Task<PagedResult<PostDto>> GetBookmarkedPostsAsync(string userId, int page, int pageSize, CancellationToken cancellationToken = default)
     {
         var bookmarks = await _unitOfWork.Bookmarks.GetByUserIdAsync(userId, page, pageSize, cancellationToken);
+        var totalCount = await _unitOfWork.Bookmarks.GetCountByUserIdAsync(userId, cancellationToken);
         
         return new PagedResult<PostDto>
         {
             Items = bookmarks.Select(b => MapPostToDto(b.Post, userId)).ToList(),
             Page = page,
             PageSize = pageSize,
-            TotalCount = bookmarks.Count()
+            TotalCount = totalCount
         };
     }
 

--- a/src/Blog.Application/Services/PostService.cs
+++ b/src/Blog.Application/Services/PostService.cs
@@ -323,12 +323,27 @@ public class PostService : IPostService
         await _unitOfWork.Posts.IncrementViewCountAsync(postId, cancellationToken);
     }
 
-    public Task UpdateTrendingScoresAsync(CancellationToken cancellationToken = default)
+    public async Task UpdateTrendingScoresAsync(CancellationToken cancellationToken = default)
     {
         // Trending score algorithm: (likes × 2 + views × 0.5 + comments × 3) / (hoursAge + 2)^1.5
-        // This would typically be run as a background job
-        // For now, it's a placeholder that could be called periodically
-        return Task.CompletedTask;
+        var posts = await _unitOfWork.Posts.GetAllAsync(cancellationToken);
+        var publishedPosts = posts.Where(p => p.Status == PostStatus.Published && p.PublishedAt.HasValue).ToList();
+
+        foreach (var post in publishedPosts)
+        {
+            var hoursAge = (DateTime.UtcNow - post.PublishedAt!.Value).TotalHours;
+            var likeCount = post.Likes?.Count ?? 0;
+            var commentCount = post.Comments?.Count ?? 0;
+            var viewCount = post.ViewCount;
+
+            var score = (likeCount * 2 + viewCount * 0.5 + commentCount * 3) / Math.Pow(hoursAge + 2, 1.5);
+            post.TrendingScore = double.IsFinite(score) ? score : 0;
+            post.TrendingScoreUpdatedAt = DateTime.UtcNow;
+
+            await _unitOfWork.Posts.UpdateAsync(post, cancellationToken);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
     }
 
     private async Task<string> GenerateUniqueSlugAsync(string title, int? excludeId, CancellationToken cancellationToken)

--- a/src/Blog.Domain/Interfaces/IRepositories.cs
+++ b/src/Blog.Domain/Interfaces/IRepositories.cs
@@ -43,6 +43,8 @@ public interface ICommentRepository
 {
     Task<Comment?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Comment>> GetByPostIdAsync(int postId, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Comment>> GetByPostIdAsync(int postId, int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<int> GetCountByPostIdAsync(int postId, CancellationToken cancellationToken = default);
     Task<IEnumerable<Comment>> GetRepliesAsync(int parentCommentId, CancellationToken cancellationToken = default);
     Task<int> CountAsync(CancellationToken cancellationToken = default);
     Task<Comment> AddAsync(Comment comment, CancellationToken cancellationToken = default);

--- a/src/Blog.Domain/Interfaces/IRepositories.cs
+++ b/src/Blog.Domain/Interfaces/IRepositories.cs
@@ -7,6 +7,7 @@ public interface IPostRepository
 {
     Task<Post?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
     Task<Post?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Post>> GetAllAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> GetAllPublishedAsync(int page, int pageSize, CancellationToken cancellationToken = default);
     Task<IEnumerable<Post>> GetByAuthorIdAsync(string authorId, int page, int pageSize, PostStatus? status = null, CancellationToken cancellationToken = default);
     Task<int> GetCountByAuthorIdAsync(string authorId, PostStatus? status = null, CancellationToken cancellationToken = default);

--- a/src/Blog.Infrastructure/Data/SeedData.cs
+++ b/src/Blog.Infrastructure/Data/SeedData.cs
@@ -69,7 +69,8 @@ public static class SeedData
             CreatedAt = DateTime.UtcNow.AddYears(-1)
         };
 
-        var adminPassword = Environment.GetEnvironmentVariable("SEED_ADMIN_PASSWORD") ?? "Admin@123";
+        var adminPassword = Environment.GetEnvironmentVariable("SEED_ADMIN_PASSWORD") 
+            ?? throw new InvalidOperationException("SEED_ADMIN_PASSWORD environment variable must be set.");
         if (await userManager.FindByEmailAsync(admin.Email) == null)
         {
             await userManager.CreateAsync(admin, adminPassword);
@@ -108,7 +109,8 @@ public static class SeedData
                 CreatedAt = DateTime.UtcNow.AddMonths(-6)
             };
 
-            var userPassword = Environment.GetEnvironmentVariable("SEED_USER_PASSWORD") ?? "User@123";
+            var userPassword = Environment.GetEnvironmentVariable("SEED_USER_PASSWORD") 
+                ?? throw new InvalidOperationException("SEED_USER_PASSWORD environment variable must be set.");
             if (await userManager.FindByEmailAsync(user.Email) == null)
             {
                 await userManager.CreateAsync(user, userPassword); // Simple password for demo

--- a/src/Blog.Infrastructure/Data/SeedData.cs
+++ b/src/Blog.Infrastructure/Data/SeedData.cs
@@ -69,9 +69,10 @@ public static class SeedData
             CreatedAt = DateTime.UtcNow.AddYears(-1)
         };
 
+        var adminPassword = Environment.GetEnvironmentVariable("SEED_ADMIN_PASSWORD") ?? "Admin@123";
         if (await userManager.FindByEmailAsync(admin.Email) == null)
         {
-            await userManager.CreateAsync(admin, "Admin@123");
+            await userManager.CreateAsync(admin, adminPassword);
             await userManager.AddToRolesAsync(admin, new[] { "Admin", "Author" });
             users.Add(admin);
         }
@@ -80,7 +81,7 @@ public static class SeedData
         {
             // Ensure password is correct
             var token = await userManager.GeneratePasswordResetTokenAsync(foundAdmin);
-            await userManager.ResetPasswordAsync(foundAdmin, token, "Admin@123");
+            await userManager.ResetPasswordAsync(foundAdmin, token, adminPassword);
             users.Add(foundAdmin);
         }
 
@@ -107,9 +108,10 @@ public static class SeedData
                 CreatedAt = DateTime.UtcNow.AddMonths(-6)
             };
 
+            var userPassword = Environment.GetEnvironmentVariable("SEED_USER_PASSWORD") ?? "User@123";
             if (await userManager.FindByEmailAsync(user.Email) == null)
             {
-                await userManager.CreateAsync(user, "User@123"); // Simple password for demo
+                await userManager.CreateAsync(user, userPassword); // Simple password for demo
                 await userManager.AddToRoleAsync(user, "Author");
                 users.Add(user);
             }

--- a/src/Blog.Infrastructure/Repositories/Repositories.cs
+++ b/src/Blog.Infrastructure/Repositories/Repositories.cs
@@ -315,6 +315,24 @@ public class CommentRepository : ICommentRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IEnumerable<Comment>> GetByPostIdAsync(int postId, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        return await _context.Comments
+            .Where(c => c.PostId == postId && c.ParentCommentId == null && !c.IsDeleted)
+            .Include(c => c.Author)
+            .Include(c => c.Replies.Where(r => !r.IsDeleted)).ThenInclude(r => r.Author)
+            .OrderByDescending(c => c.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> GetCountByPostIdAsync(int postId, CancellationToken cancellationToken = default)
+    {
+        return await _context.Comments
+            .CountAsync(c => c.PostId == postId && c.ParentCommentId == null && !c.IsDeleted, cancellationToken);
+    }
+
     public async Task<IEnumerable<Comment>> GetRepliesAsync(int parentCommentId, CancellationToken cancellationToken = default)
     {
         return await _context.Comments

--- a/src/Blog.Infrastructure/Repositories/Repositories.cs
+++ b/src/Blog.Infrastructure/Repositories/Repositories.cs
@@ -32,7 +32,16 @@ public class PostRepository : IPostRepository
             .Include(p => p.PostTags).ThenInclude(pt => pt.Tag)
             .Include(p => p.Likes)
             .Include(p => p.Bookmarks)
+            .Include(p => p.Comments)
             .FirstOrDefaultAsync(p => p.Slug == slug, cancellationToken);
+    }
+
+    public async Task<IEnumerable<Post>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Posts
+            .Include(p => p.Likes)
+            .Include(p => p.Comments)
+            .ToListAsync(cancellationToken);
     }
 
     public async Task<IEnumerable<Post>> GetAllPublishedAsync(int page, int pageSize, CancellationToken cancellationToken = default)

--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -190,7 +190,7 @@ public class NewsletterController : ControllerBase
 
         try
         {
-            await _emailService.SendEmailAsync(subscriber.Email, subject, body);
+            await _emailService.SendNotificationEmailAsync(subscriber.Email, subject, body);
             _logger.LogInformation("Confirmation email sent to: {Email}", subscriber.Email);
         }
         catch (Exception ex)

--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -1,4 +1,5 @@
 using Blog.Domain.Entities;
+using Blog.Application.Services;
 using Blog.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -13,11 +14,13 @@ public class NewsletterController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
     private readonly ILogger<NewsletterController> _logger;
+    private readonly IEmailService _emailService;
 
-    public NewsletterController(ApplicationDbContext context, ILogger<NewsletterController> logger)
+    public NewsletterController(ApplicationDbContext context, ILogger<NewsletterController> logger, IEmailService emailService)
     {
         _context = context;
         _logger = logger;
+        _emailService = emailService;
     }
 
     [HttpPost("subscribe")]
@@ -50,12 +53,18 @@ public class NewsletterController : ControllerBase
                 }
                 else
                 {
-                    // Reactivate subscription
-                    existing.IsActive = true;
+                    // Re-subscribe requires confirmation again
+                    existing.ConfirmationToken = Guid.NewGuid().ToString("N");
+                    existing.IsActive = false;
+                    existing.IsConfirmed = false;
                     existing.UnsubscribedAt = null;
                     existing.SubscribedAt = DateTime.UtcNow;
                     await _context.SaveChangesAsync();
-                    return Ok(new { success = true, message = "Welcome back! Your subscription has been reactivated." });
+
+                    // Send confirmation email
+                    await SendConfirmationEmailAsync(existing);
+
+                    return Ok(new { success = true, message = "Welcome back! Please check your email to confirm your subscription." });
                 }
             }
 
@@ -65,15 +74,15 @@ public class NewsletterController : ControllerBase
                 Email = email,
                 SubscribedAt = DateTime.UtcNow,
                 ConfirmationToken = Guid.NewGuid().ToString("N"),
-                IsActive = false  // GDPR: require email confirmation before activation
+                IsActive = false,
+                IsConfirmed = false
             };
 
             _context.Subscribers.Add(subscriber);
             await _context.SaveChangesAsync();
 
             // Send confirmation email (GDPR double opt-in)
-            var confirmationLink = Url.Action("ConfirmNewsletter", "Newsletter", new { token = subscriber.ConfirmationToken, email = subscriber.Email }, Request.Scheme);
-            // Note: In production, inject IEmailService and send the confirmation email
+            await SendConfirmationEmailAsync(subscriber);
 
             _logger.LogInformation("New newsletter subscriber (pending confirmation): {Email}", email);
 
@@ -82,6 +91,49 @@ public class NewsletterController : ControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error subscribing email: {Email}", email);
+            return StatusCode(500, new { success = false, message = "Something went wrong. Please try again later." });
+        }
+    }
+
+    [HttpGet("confirm")]
+    public async Task<IActionResult> Confirm([FromQuery] string token, [FromQuery] string email)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(email))
+        {
+            return BadRequest(new { success = false, message = "Invalid confirmation request." });
+        }
+
+        email = email.Trim().ToLowerInvariant();
+
+        try
+        {
+            var subscriber = await _context.Subscribers
+                .FirstOrDefaultAsync(s => s.Email == email && s.ConfirmationToken == token);
+
+            if (subscriber == null)
+            {
+                return BadRequest(new { success = false, message = "Invalid confirmation token." });
+            }
+
+            if (subscriber.IsConfirmed && subscriber.IsActive)
+            {
+                return Ok(new { success = true, message = "You're already confirmed and subscribed!" });
+            }
+
+            // Activate subscription after confirmation
+            subscriber.IsConfirmed = true;
+            subscriber.IsActive = true;
+            subscriber.ConfirmedAt = DateTime.UtcNow;
+            subscriber.ConfirmationToken = null;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Newsletter confirmed: {Email}", email);
+
+            return Ok(new { success = true, message = "Your subscription has been confirmed. Thank you!" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error confirming newsletter: {Email}", email);
             return StatusCode(500, new { success = false, message = "Something went wrong. Please try again later." });
         }
     }
@@ -119,6 +171,32 @@ public class NewsletterController : ControllerBase
         _logger.LogInformation("Newsletter unsubscribe: {Email}", email);
 
         return Ok(new { success = true, message = "You have been unsubscribed successfully." });
+    }
+
+    private async Task SendConfirmationEmailAsync(Subscriber subscriber)
+    {
+        var confirmationLink = Url.Action("Confirm", "ApiNewsletter",
+            new { token = subscriber.ConfirmationToken, email = subscriber.Email },
+            Request.Scheme);
+
+        var subject = "Confirm your newsletter subscription";
+        var body = $@"<html><body>
+<h2>Welcome!</h2>
+<p>Please confirm your newsletter subscription by clicking the link below:</p>
+<p><a href=""{confirmationLink}"">Confirm Subscription</a></p>
+<p>Or copy and paste this link: {confirmationLink}</p>
+<p>If you didn't request this, please ignore this email.</p>
+</body></html>";
+
+        try
+        {
+            await _emailService.SendEmailAsync(subscriber.Email, subject, body);
+            _logger.LogInformation("Confirmation email sent to: {Email}", subscriber.Email);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send confirmation email: {Email}", subscriber.Email);
+        }
     }
 
     private static bool IsValidEmail(string email)

--- a/src/Blog.Web/Pages/Post/Details.cshtml
+++ b/src/Blog.Web/Pages/Post/Details.cshtml
@@ -215,7 +215,7 @@ else
 
     <!-- Comments Section -->
     <section id="comments" class="comments-section">
-        <h2 class="section-title">Comments (@Model.Comments.Count)</h2>
+        <h2 class="section-title">Comments (@Model.Comments.TotalCount)</h2>
 
         @if (User.Identity?.IsAuthenticated == true)
         {
@@ -237,7 +237,7 @@ else
         }
 
         <div class="comments-list">
-            @foreach (var comment in Model.Comments)
+            @foreach (var comment in Model.Comments.Items)
             {
                 <div class="comment-item card" id="comment-@comment.Id">
                     <div class="card-body">

--- a/src/Blog.Web/Pages/Post/Details.cshtml.cs
+++ b/src/Blog.Web/Pages/Post/Details.cshtml.cs
@@ -23,10 +23,10 @@ public class DetailsModel : PageModel
     }
 
     public PostDetailDto? Post { get; set; }
-    public List<CommentDto> Comments { get; set; } = new();
+    public PagedResult<CommentDto> Comments { get; set; } = new();
     public List<PostDto> RelatedPosts { get; set; } = new();
 
-    public async Task<IActionResult> OnGetAsync(string slug)
+    public async Task<IActionResult> OnGetAsync(string slug, int page = 1)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         Post = await _postService.GetBySlugAsync(slug, userId);
@@ -37,7 +37,7 @@ public class DetailsModel : PageModel
         // Increment view count
         await _postService.IncrementViewAsync(Post.Id);
 
-        Comments = (await _commentService.GetByPostIdAsync(Post.Id)).ToList();
+        Comments = await _commentService.GetByPostIdAsync(Post.Id, page);
         RelatedPosts = await _postService.GetRelatedAsync(Post.Id, 3, userId);
 
         return Page();


### PR DESCRIPTION
## Summary

Previously,  only recorded unique views in the  table but never incremented the post's  field, causing the view count displayed on posts to remain stuck at 0 or the initial count.

## Fix

Now calls  after saving the  record to properly update the displayed view count.

## Changes
-  - Added call to  after recording a unique view