### PR TITLE
Fix #26: NullReferenceException in PostService.MapToDtoAsync

### DIFF
--- a/src/Blog.Application/Services/PostService.cs
+++ b/src/Blog.Application/Services/PostService.cs
@@ -394,9 +394,9 @@ public class PostService : IPostService
             IsLiked = isLiked,
             IsBookmarked = isBookmarked,
             Author = MapUserToDto(post.Author),
-            Tags = post.PostTags?.Select(pt => new TagDto
+            Tags = post.PostTags?.Where(pt => pt.Tag != null).Select(pt => new TagDto
             {
-                Id = pt.Tag.Id,
+                Id = pt.Tag!.Id,
                 Name = pt.Tag.Name,
                 Slug = pt.Tag.Slug,
                 Color = pt.Tag.Color


### PR DESCRIPTION
## Fixes Issue #26

Add null check for pt.Tag before accessing its properties in PostService.MapToDtoAsync. This prevents NullReferenceException when Tag navigation property is not loaded.

### Changes
- Added Where filter before Select to exclude null Tags
- Added null-forgiving operator for null-eligible reference