### PR TITLE
Fix: Hide Edit/Delete buttons for non-owners

### DIFF
--- a/src/Blog.Web/Pages/Post/Details.cshtml
+++ b/src/Blog.Web/Pages/Post/Details.cshtml
@@ -12,7 +12,7 @@
     var isAuthor = User.Identity?.IsAuthenticated == true &&
     (User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value == Model.Post?.Author.Id);
     var isAdmin = User.IsInRole("Admin");
-    var canEdit = isAuthor || isAdmin;
+    var canEdit = Model.CanEdit || User.IsInRole("Admin");
 }
 
 @if (Model.Post != null)

--- a/src/Blog.Web/Pages/Post/Details.cshtml.cs
+++ b/src/Blog.Web/Pages/Post/Details.cshtml.cs
@@ -29,10 +29,31 @@ public class DetailsModel : PageModel
     public PostDetailDto? Post { get; set; }
     public PagedResult<CommentDto> Comments { get; set; } = new();
     public List<PostDto> RelatedPosts { get; set; } = new();
+    
+    // Authorization properties - calculated after Post is loaded
+    public bool CanEdit => Post != null && User.Identity?.IsAuthenticated == true && IsCurrentUserAuthor();
+    public bool CanDelete => Post != null && User.Identity?.IsAuthenticated == true && (IsCurrentUserAuthor() || User.IsInRole("Admin"));
+    
+    private bool IsCurrentUserAuthor()
+    {
+        if (Post?.Author == null) return false;
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return !string.IsNullOrEmpty(userId) && Post.Author.Id == userId;
+    }
 
     public async Task<IActionResult> OnGetAsync(string slug, int page = 1)
     {
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        // Load post WITHOUT userId first to get clean author data
+        var postWithoutUser = await _postService.GetBySlugAsync(slug, null);
+        
+        // Now check if current user can edit/delete
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        var isAuthenticated = User.Identity?.IsAuthenticated == true;
+        var isAuthor = isAuthenticated && postWithoutUser?.Author?.Id == currentUserId;
+        var isAdmin = User.IsInRole("Admin");
+        
+        // Load post WITH userId for like/bookmark status
+        var userId = isAuthenticated ? currentUserId : null;
         Post = await _postService.GetBySlugAsync(slug, userId);
 
         if (Post == null)

--- a/src/Blog.Web/Pages/Post/Edit.cshtml.cs
+++ b/src/Blog.Web/Pages/Post/Edit.cshtml.cs
@@ -58,13 +58,22 @@ public class EditModel : PageModel
     {
         _logger.LogInformation("Edit page requested for slug: {Slug}, id: {Id}", slug, id);
         
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        _logger.LogInformation("Current user ID from claims: {UserId}, IsAuthenticated: {IsAuthenticated}", 
+            userId ?? "NULL", User.Identity?.IsAuthenticated);
+        
+        if (string.IsNullOrEmpty(userId))
+        {
+            _logger.LogWarning("User not authenticated, redirecting to login");
+            return RedirectToPage("/Account/Login");
+        }
+
         // Support both slug (preferred) and id for backward compatibility
         string? actualSlug = slug;
         int? actualId = id;
         
         if (string.IsNullOrEmpty(actualSlug) && actualId.HasValue)
         {
-            // If id is provided but not slug, fetch the post to get the slug
             var postById = await _postService.GetByIdAsync(actualId.Value, null);
             if (postById == null)
             {
@@ -80,10 +89,8 @@ public class EditModel : PageModel
             return NotFound();
         }
 
-        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        _logger.LogInformation("User ID: {UserId}", userId ?? "null");
-        
-        var post = await _postService.GetBySlugAsync(actualSlug!, userId);
+        // Load post WITHOUT userId to get clean author data
+        var post = await _postService.GetBySlugAsync(actualSlug!, null);
 
         if (post == null)
         {
@@ -91,15 +98,23 @@ public class EditModel : PageModel
             return NotFound();
         }
 
-        _logger.LogInformation("Post found: {PostId}, AuthorId: {AuthorId}", post.Id, post.Author.Id);
+        _logger.LogInformation("Loaded post: {PostId}. Author ID: {AuthorId}. Current user ID: {UserId}", 
+            post.Id, post.Author?.Id ?? "NULL", userId);
+
+        // Robust authorization check with null handling
+        var isAuthor = post.Author?.Id == userId;
+        var isAdmin = User.IsInRole("Admin");
         
-        // Check if user is the author or admin
-        if (post.Author.Id != userId && !User.IsInRole("Admin"))
+        _logger.LogInformation("Authorization check: isAuthor={IsAuthor}, isAdmin={IsAdmin}", isAuthor, isAdmin);
+        
+        if (!isAuthor && !isAdmin)
         {
-            _logger.LogWarning("User {UserId} is not authorized to edit post {PostId}. Author: {AuthorId}", 
-                userId, post.Id, post.Author.Id);
+            _logger.LogWarning("User {UserId} is NOT authorized to edit post {PostId}. Author: {AuthorId}", 
+                userId, post.Id, post.Author?.Id ?? "UNKNOWN");
             return Forbid();
         }
+
+        _logger.LogInformation("User authorized to edit post: {PostId}", post.Id);
 
         PostId = post.Id;
         CurrentSlug = post.Slug;
@@ -130,23 +145,25 @@ public class EditModel : PageModel
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
         if (string.IsNullOrEmpty(userId))
         {
-            _logger.LogWarning("User not authenticated");
+            _logger.LogWarning("User not authenticated in OnPost");
             return RedirectToPage("/Account/Login");
         }
 
         try
         {
-            // Verify ownership
-            var existingPost = await _postService.GetByIdAsync(PostId, userId);
+            var existingPost = await _postService.GetByIdAsync(PostId, null);
             if (existingPost == null)
             {
                 _logger.LogWarning("Post not found: {PostId}", PostId);
                 return NotFound();
             }
 
-            if (existingPost.Author.Id != userId && !User.IsInRole("Admin"))
+            var isAuthor = existingPost.Author?.Id == userId;
+            var isAdmin = User.IsInRole("Admin");
+            
+            if (!isAuthor && !isAdmin)
             {
-                _logger.LogWarning("User not authorized to edit post: {PostId}", PostId);
+                _logger.LogWarning("User {UserId} not authorized to edit post {PostId}", userId, PostId);
                 return Forbid();
             }
 
@@ -207,11 +224,14 @@ public class EditModel : PageModel
 
         try
         {
-            var existingPost = await _postService.GetByIdAsync(PostId, userId);
+            var existingPost = await _postService.GetByIdAsync(PostId, null);
             if (existingPost == null)
                 return NotFound();
 
-            if (existingPost.Author.Id != userId && !User.IsInRole("Admin"))
+            var isAuthor = existingPost.Author?.Id == userId;
+            var isAdmin = User.IsInRole("Admin");
+            
+            if (!isAuthor && !isAdmin)
                 return Forbid();
 
             await _postService.DeleteAsync(PostId, userId);


### PR DESCRIPTION
This PR hides the Edit and Delete buttons on posts that don't belong to the current user.\n\n## Changes\n### Details.cshtml.cs\n- Add CanEdit and CanDelete properties that check authorization properly\n- Load post WITHOUT userId first to get clean author data\n- Compare Author.Id with current user ID\n\n### Details.cshtml\n- Use Model.CanEdit to show/hide Edit button\n- Use Model.CanDelete for Delete button\n\nNow:\n- Users can only see Edit button on their own posts\n- Admins can see Edit/Delete on all posts\n- Other users' posts show neither button