### PR TITLE
Fix #61: Log email validation exceptions instead of silently ignoring

### DIFF
--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -199,15 +199,16 @@ public class NewsletterController : ControllerBase
         }
     }
 
-    private static bool IsValidEmail(string email)
+    private bool IsValidEmail(string email)
     {
         try
         {
             var addr = new System.Net.Mail.MailAddress(email);
             return addr.Address == email;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogDebug(ex, "Invalid email format: {Email}", email);
             return false;
         }
     }


### PR DESCRIPTION
Fixes Issue #61 - The IsValidEmail method had an empty catch block that silently swallowed all exceptions without logging. This makes debugging email validation issues difficult. Now logs the exception at Debug level for easier troubleshooting.