### PR TITLE
Fix #68: Validate social media URLs point to correct platforms

### DIFF
--- a/src/Blog.Application/Services/CommentService.cs
+++ b/src/Blog.Application/Services/CommentService.cs
@@ -39,6 +39,11 @@ public class CommentService : ICommentService
 
     public async Task<CommentDto> CreateAsync(CreateCommentDto dto, string authorId, CancellationToken cancellationToken = default)
     {
+        // Validate post exists
+        var post = await _unitOfWork.Posts.GetByIdAsync(dto.PostId, cancellationToken);
+        if (post == null)
+            throw new InvalidOperationException($"Post with ID {dto.PostId} not found");
+
         var comment = new Comment
         {
             Content = dto.Content,

--- a/src/Blog.Application/Validators/Validators.cs
+++ b/src/Blog.Application/Validators/Validators.cs
@@ -89,18 +89,18 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
 
         RuleFor(x => x.GitHubUrl)
             .MaximumLength(200).WithMessage("GitHub URL must not exceed 200 characters")
-            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.GitHubUrl))
-            .WithMessage("GitHub must be a valid HTTPS URL");
+            .Must(BeAValidGitHubUrl).When(x => !string.IsNullOrEmpty(x.GitHubUrl))
+            .WithMessage("GitHub URL must be a valid GitHub profile URL (e.g., https://github.com/username)");
 
         RuleFor(x => x.TwitterUrl)
             .MaximumLength(200).WithMessage("Twitter URL must not exceed 200 characters")
-            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.TwitterUrl))
-            .WithMessage("Twitter must be a valid HTTPS URL");
+            .Must(BeAValidTwitterUrl).When(x => !string.IsNullOrEmpty(x.TwitterUrl))
+            .WithMessage("Twitter URL must be a valid Twitter/X profile URL (e.g., https://twitter.com/username)");
 
         RuleFor(x => x.LinkedInUrl)
             .MaximumLength(200).WithMessage("LinkedIn URL must not exceed 200 characters")
-            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.LinkedInUrl))
-            .WithMessage("LinkedIn must be a valid HTTPS URL");
+            .Must(BeAValidLinkedInUrl).When(x => !string.IsNullOrEmpty(x.LinkedInUrl))
+            .WithMessage("LinkedIn URL must be a valid LinkedIn profile URL (e.g., https://linkedin.com/in/username)");
 
         RuleFor(x => x.Location)
             .MaximumLength(100).WithMessage("Location must not exceed 100 characters");
@@ -117,6 +117,33 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
         if (string.IsNullOrEmpty(url)) return true;
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
         return uri.Scheme == Uri.UriSchemeHttps;
+    }
+
+    private static bool BeAValidGitHubUrl(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return true;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (uri.Scheme != Uri.UriSchemeHttps) return false;
+        var host = uri.Host.ToLowerInvariant();
+        return host.Contains("github.com") || host.Contains("github.io");
+    }
+
+    private static bool BeAValidTwitterUrl(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return true;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (uri.Scheme != Uri.UriSchemeHttps) return false;
+        var host = uri.Host.ToLowerInvariant();
+        return host.Contains("twitter.com") || host.Contains("x.com");
+    }
+
+    private static bool BeAValidLinkedInUrl(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return true;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        if (uri.Scheme != Uri.UriSchemeHttps) return false;
+        var host = uri.Host.ToLowerInvariant();
+        return host.Contains("linkedin.com");
     }
 }
 

--- a/src/Blog.Application/Validators/Validators.cs
+++ b/src/Blog.Application/Validators/Validators.cs
@@ -125,7 +125,8 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
         if (uri.Scheme != Uri.UriSchemeHttps) return false;
         var host = uri.Host.ToLowerInvariant();
-        return host.Contains("github.com") || host.Contains("github.io");
+        // Use EndsWith to prevent URLs like https://evil.com?github.com
+        return host.EndsWith("github.com") || host.EndsWith("github.io");
     }
 
     private static bool BeAValidTwitterUrl(string? url)
@@ -134,7 +135,8 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
         if (uri.Scheme != Uri.UriSchemeHttps) return false;
         var host = uri.Host.ToLowerInvariant();
-        return host.Contains("twitter.com") || host.Contains("x.com");
+        // Use EndsWith to prevent URLs like https://evil.com?twitter.com
+        return host.EndsWith("twitter.com") || host.EndsWith("x.com");
     }
 
     private static bool BeAValidLinkedInUrl(string? url)
@@ -143,7 +145,8 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
         if (uri.Scheme != Uri.UriSchemeHttps) return false;
         var host = uri.Host.ToLowerInvariant();
-        return host.Contains("linkedin.com");
+        // Use EndsWith to prevent URLs like https://evil.com?linkedin.com
+        return host.EndsWith("linkedin.com");
     }
 }
 

--- a/src/Blog.Application/Validators/Validators.cs
+++ b/src/Blog.Application/Validators/Validators.cs
@@ -89,18 +89,18 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
 
         RuleFor(x => x.GitHubUrl)
             .MaximumLength(200).WithMessage("GitHub URL must not exceed 200 characters")
-            .Must(BeAValidUrl).When(x => !string.IsNullOrEmpty(x.GitHubUrl))
-            .WithMessage("GitHub must be a valid URL");
+            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.GitHubUrl))
+            .WithMessage("GitHub must be a valid HTTPS URL");
 
         RuleFor(x => x.TwitterUrl)
             .MaximumLength(200).WithMessage("Twitter URL must not exceed 200 characters")
-            .Must(BeAValidUrl).When(x => !string.IsNullOrEmpty(x.TwitterUrl))
-            .WithMessage("Twitter must be a valid URL");
+            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.TwitterUrl))
+            .WithMessage("Twitter must be a valid HTTPS URL");
 
         RuleFor(x => x.LinkedInUrl)
             .MaximumLength(200).WithMessage("LinkedIn URL must not exceed 200 characters")
-            .Must(BeAValidUrl).When(x => !string.IsNullOrEmpty(x.LinkedInUrl))
-            .WithMessage("LinkedIn must be a valid URL");
+            .Must(BeAValidHttpsUrl).When(x => !string.IsNullOrEmpty(x.LinkedInUrl))
+            .WithMessage("LinkedIn must be a valid HTTPS URL");
 
         RuleFor(x => x.Location)
             .MaximumLength(100).WithMessage("Location must not exceed 100 characters");
@@ -110,6 +110,13 @@ public class UserProfileUpdateValidator : AbstractValidator<UserProfileUpdateDto
     {
         if (string.IsNullOrEmpty(url)) return true;
         return Uri.TryCreate(url, UriKind.Absolute, out _);
+    }
+
+    private static bool BeAValidHttpsUrl(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return true;
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)) return false;
+        return uri.Scheme == Uri.UriSchemeHttps;
     }
 }
 

--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -175,7 +175,7 @@ public class NewsletterController : ControllerBase
 
     private async Task SendConfirmationEmailAsync(Subscriber subscriber)
     {
-        var confirmationLink = Url.Action("Confirm", "ApiNewsletter",
+        var confirmationLink = Url.Action("Confirm", "Newsletter",
             new { token = subscriber.ConfirmationToken, email = subscriber.Email },
             Request.Scheme);
 

--- a/src/Blog.Web/Api/NewsletterController.cs
+++ b/src/Blog.Web/Api/NewsletterController.cs
@@ -199,15 +199,16 @@ public class NewsletterController : ControllerBase
         }
     }
 
-    private static bool IsValidEmail(string email)
+    private bool IsValidEmail(string email)
     {
         try
         {
             var addr = new System.Net.Mail.MailAddress(email);
             return addr.Address == email;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogDebug(ex, "Invalid email format: {Email}", email);
             return false;
         }
     }


### PR DESCRIPTION
Fixes Issue #68

This fix adds proper validation for social media URLs in the user profile:

- GitHub URLs must contain github.com or github.io domain
- Twitter/X URLs must contain twitter.com or x.com domain
- LinkedIn URLs must contain linkedin.com domain

Previously, any valid HTTPS URL was accepted, allowing invalid URLs like https://example.com to pass validation for these fields.