### PR TITLE
Fix: Null check for orphaned authors

### DIFF
--- a/src/Blog.Application/Services/CommentService.cs
+++ b/src/Blog.Application/Services/CommentService.cs
@@ -103,13 +103,13 @@ public class CommentService : ICommentService
             IsDeleted = comment.IsDeleted,
             CreatedAt = comment.CreatedAt,
             ParentCommentId = comment.ParentCommentId,
-            Author = new UserDto
+            Author = comment.Author != null ? new UserDto
             {
                 Id = comment.Author.Id,
                 UserName = comment.Author.UserName ?? string.Empty,
                 DisplayName = comment.Author.DisplayName,
                 AvatarUrl = comment.Author.AvatarUrl
-            },
+            } : null,
             Replies = comment.Replies?.Select(MapToDto).ToList() ?? new List<CommentDto>()
         };
     }

--- a/src/Blog.Application/Services/PostService.cs
+++ b/src/Blog.Application/Services/PostService.cs
@@ -393,7 +393,7 @@ public class PostService : IPostService
             BookmarkCount = post.Bookmarks?.Count ?? 0,
             IsLiked = isLiked,
             IsBookmarked = isBookmarked,
-            Author = MapUserToDto(post.Author),
+            Author = post.Author != null ? MapUserToDto(post.Author) : null,
             Tags = post.PostTags?.Where(pt => pt.Tag != null).Select(pt => new TagDto
             {
                 Id = pt.Tag!.Id,


### PR DESCRIPTION
## Summary
- Added null checks in PostService.MapToDtoAsync and CommentService.MapToDto to handle cases where the author has been deleted\n- Previously, if a post or comment's author was removed from the database, this would throw NullReferenceException\n- Now maps to null Author instead of crashing\n\n## Changes\n- PostService.cs: Check post.Author != null before mapping\n- CommentService.cs: Check comment.Author != null before mapping