### PR TITLE
Fix #80: Add null/empty checks to GetBy* methods

### DIFF
--- a/src/Blog.Infrastructure/Repositories/Repositories.cs
+++ b/src/Blog.Infrastructure/Repositories/Repositories.cs
@@ -64,6 +64,11 @@ public class PostRepository : IPostRepository
 
     public async Task<IEnumerable<Post>> GetByAuthorIdAsync(string authorId, int page, int pageSize, PostStatus? status = null, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(authorId))
+        {
+            return Enumerable.Empty<Post>();
+        }
+
         var baseQuery = _context.Posts.Where(p => p.AuthorId == authorId);
 
         if (status.HasValue)
@@ -92,6 +97,11 @@ public class PostRepository : IPostRepository
 
     public async Task<IEnumerable<Post>> GetByTagAsync(string tagSlug, int page, int pageSize, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(tagSlug))
+        {
+            return Enumerable.Empty<Post>();
+        }
+
         return await _context.Posts
             .Where(p => p.Status == PostStatus.Published && p.PostTags.Any(pt => pt.Tag.Slug == tagSlug))
             .Include(p => p.Author)
@@ -622,6 +632,11 @@ public class UserRepository : IUserRepository
 
     public async Task<ApplicationUser?> GetByUsernameAsync(string username, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(username))
+        {
+            return null;
+        }
+
         return await _context.Users.FirstOrDefaultAsync(u => u.UserName == username, cancellationToken);
     }
 

--- a/src/Blog.Infrastructure/Repositories/Repositories.cs
+++ b/src/Blog.Infrastructure/Repositories/Repositories.cs
@@ -27,6 +27,11 @@ public class PostRepository : IPostRepository
 
     public async Task<Post?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(slug))
+        {
+            return null;
+        }
+
         return await _context.Posts
             .Include(p => p.Author)
             .Include(p => p.PostTags).ThenInclude(pt => pt.Tag)
@@ -231,6 +236,11 @@ public class TagRepository : ITagRepository
 
     public async Task<Tag?> GetBySlugAsync(string slug, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrEmpty(slug))
+        {
+            return null;
+        }
+
         return await _context.Tags.FirstOrDefaultAsync(t => t.Slug == slug, cancellationToken);
     }
 


### PR DESCRIPTION
Fixes Issue #80

Adds null/empty validation to GetByAuthorIdAsync, GetByTagAsync, and GetByUsernameAsync methods to prevent unnecessary database queries and potential issues when string parameters are null or empty.