### PR TITLE
Fix: Add null check for created comment in CommentService.CreateAsync

### DIFF
--- a/src/Blog.Application/Services/CommentService.cs
+++ b/src/Blog.Application/Services/CommentService.cs
@@ -58,7 +58,9 @@ public class CommentService : ICommentService
 
         // Fetch with author info
         var created = await _unitOfWork.Comments.GetByIdAsync(comment.Id, cancellationToken);
-        return MapToDto(created!);
+        if (created == null)
+            throw new InvalidOperationException($"Failed to retrieve comment with ID {comment.Id} after creation.");
+        return MapToDto(created);
     }
 
     public async Task<CommentDto> UpdateAsync(int commentId, string content, string authorId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fixes an issue where the created comment could be null after creation, causing a null reference exception.