### PR TITLE
Fix: newsletter confirmation broken link (missing NewsletterConfirm page)

### DIFF
--- a/src/Blog.Web/Pages/Newsletter.cshtml.cs
+++ b/src/Blog.Web/Pages/Newsletter.cshtml.cs
@@ -1,8 +1,10 @@
 using Blog.Application.Services;
 using Blog.Domain.Entities;
+using Blog.Infrastructure.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations;
 
 namespace Blog.Web.Pages;
@@ -12,15 +14,18 @@ public class NewsletterModel : PageModel
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IEmailService _emailService;
     private readonly ILogger<NewsletterModel> _logger;
+    private readonly ApplicationDbContext _context;
 
     public NewsletterModel(
         UserManager<ApplicationUser> userManager,
         IEmailService emailService,
-        ILogger<NewsletterModel> logger)
+        ILogger<NewsletterModel> logger,
+        ApplicationDbContext context)
     {
         _userManager = userManager;
         _emailService = emailService;
         _logger = logger;
+        _context = context;
     }
 
     [BindProperty]
@@ -79,30 +84,57 @@ public class NewsletterModel : PageModel
     private async Task<IActionResult> HandleSubscribeAsync()
     {
         // GDPR: Require double opt-in - send confirmation email instead of immediate subscription
-        var user = IsAuthenticated ? await _userManager.GetUserAsync(User) : null;
+        var email = Input.Email.Trim().ToLowerInvariant();
 
-        // Generate confirmation token
+        // Find or create subscriber record so the confirmation link works
+        var subscriber = await _context.Subscribers
+            .FirstOrDefaultAsync(s => s.Email == email);
+
+        var isNew = subscriber == null;
         var confirmationToken = Guid.NewGuid().ToString("N");
-        var confirmationLink = Url.Page("/NewsletterConfirm", null, new { token = confirmationToken, email = Input.Email }, Request.Scheme);
 
-        // Store pending subscription in temp data or use a pending subscriptions table
-        // For simplicity, we'll send a confirmation email
+        if (subscriber == null)
+        {
+            subscriber = new Subscriber
+            {
+                Email = email,
+                ConfirmationToken = confirmationToken,
+                IsActive = false,
+                IsConfirmed = false,
+                SubscribedAt = DateTime.UtcNow
+            };
+            _context.Subscribers.Add(subscriber);
+        }
+        else
+        {
+            subscriber.ConfirmationToken = confirmationToken;
+            subscriber.IsActive = false;
+            subscriber.IsConfirmed = false;
+            subscriber.UnsubscribedAt = null;
+            subscriber.SubscribedAt = DateTime.UtcNow;
+        }
+
+        await _context.SaveChangesAsync();
+
+        // Generate confirmation link pointing to the NewsletterConfirm page
+        var confirmationLink = Url.Page("/NewsletterConfirm", null, new { token = confirmationToken, email }, Request.Scheme);
+
         var emailSent = await _emailService.SendNotificationEmailAsync(
-            Input.Email,
+            email,
             "Confirm your newsletter subscription",
-            $"<p>Please confirm your newsletter subscription by clicking <a href='{confirmationLink}'>here</a>.</p>");
+            $"<p>Please confirm your newsletter subscription by clicking <a href='{confirmationLink}'>here</a>.</p><p>Or copy this link: {confirmationLink}</p>");
 
         if (emailSent)
         {
             StatusMessage = "Please check your email to confirm your subscription.";
             IsSuccess = true;
-            _logger.LogInformation("Confirmation email sent to {Email} for newsletter", Input.Email);
+            _logger.LogInformation("Newsletter confirmation email sent to {Email} (isNew={IsNew})", email, isNew);
         }
         else
         {
             StatusMessage = "Failed to send confirmation email. Please try again later.";
             IsSuccess = false;
-            _logger.LogWarning("Failed to send confirmation email to {Email}", Input.Email);
+            _logger.LogWarning("Failed to send newsletter confirmation email to {Email}", email);
         }
 
         return Page();

--- a/src/Blog.Web/Pages/NewsletterConfirm.cshtml
+++ b/src/Blog.Web/Pages/NewsletterConfirm.cshtml
@@ -1,0 +1,45 @@
+@page
+@model Blog.Web.Pages.NewsletterConfirmModel
+@{
+    ViewData["Title"] = "Confirm Newsletter Subscription";
+}
+
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-6">
+            <div class="card shadow border-0">
+                <div class="card-body p-5 text-center">
+                    @if (Model.IsSuccess)
+                    {
+                        <div class="mb-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="bi bi-check-circle-fill text-success" viewBox="0 0 16 16">
+                                <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.579 5.303 7.396a.75.75 0 1 0-1.06 1.06l2.4 2.4a.75.75 0 0 0 1.14-.06l3.84-4.326a.75.75 0 0 0-.03-1.04"/>
+                            </svg>
+                        </div>
+                        <h1 class="display-6 fw-bold text-success mb-3">Confirmed!</h1>
+                        <p class="lead">@Model.StatusMessage</p>
+                        <p class="text-muted">You'll now receive our latest posts and tech insights.</p>
+                        <a href="/" class="btn btn-primary mt-3">
+                            <i class="fas fa-home me-2"></i>Back to Home
+                        </a>
+                    }
+                    else
+                    {
+                        <div class="mb-4">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" class="bi bi-exclamation-circle-fill text-danger" viewBox="0 0 16 16">
+                                <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293z"/>
+                                <path d="M8 4.5a.5.5 0 0 1 .5.5v3a.5.5 0 0 1-1 0v-3a.5.5 0 0 1 .5-.5"/>
+                                <path d="M8 10a.5.5 0 0 1 .5.5v.5a.5.5 0 0 1-1 0v-.5A.5.5 0 0 1 8 10"/>
+                            </svg>
+                        </div>
+                        <h1 class="display-6 fw-bold text-danger mb-3">Confirmation Failed</h1>
+                        <p class="lead">@Model.StatusMessage</p>
+                        <a href="/Newsletter" class="btn btn-outline-primary mt-3">
+                            <i class="fas fa-envelope me-2"></i>Try Again
+                        </a>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Blog.Web/Pages/NewsletterConfirm.cshtml.cs
+++ b/src/Blog.Web/Pages/NewsletterConfirm.cshtml.cs
@@ -1,0 +1,75 @@
+using Blog.Domain.Entities;
+using Blog.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace Blog.Web.Pages;
+
+public class NewsletterConfirmModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+    private readonly ILogger<NewsletterConfirmModel> _logger;
+
+    public NewsletterConfirmModel(ApplicationDbContext context, ILogger<NewsletterConfirmModel> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public string? StatusMessage { get; set; }
+    public bool IsSuccess { get; set; }
+
+    public async Task<IActionResult> OnGetAsync(string? token, string? email)
+    {
+        if (string.IsNullOrWhiteSpace(token) || string.IsNullOrWhiteSpace(email))
+        {
+            StatusMessage = "Invalid confirmation link. Please check your email and try again.";
+            IsSuccess = false;
+            return Page();
+        }
+
+        email = email.Trim().ToLowerInvariant();
+
+        try
+        {
+            var subscriber = await _context.Subscribers
+                .FirstOrDefaultAsync(s => s.Email == email && s.ConfirmationToken == token);
+
+            if (subscriber == null)
+            {
+                _logger.LogWarning("Invalid newsletter confirmation attempt for {Email}", email);
+                StatusMessage = "Invalid confirmation token. The link may have expired or already been used.";
+                IsSuccess = false;
+                return Page();
+            }
+
+            if (subscriber.IsConfirmed && subscriber.IsActive)
+            {
+                StatusMessage = "You're already confirmed and subscribed!";
+                IsSuccess = true;
+                return Page();
+            }
+
+            // Activate subscription after confirmation
+            subscriber.IsConfirmed = true;
+            subscriber.IsActive = true;
+            subscriber.ConfirmedAt = DateTime.UtcNow;
+            subscriber.ConfirmationToken = null;
+            await _context.SaveChangesAsync();
+
+            _logger.LogInformation("Newsletter confirmed via page link: {Email}", email);
+
+            StatusMessage = "Your subscription has been confirmed. Thank you!";
+            IsSuccess = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error confirming newsletter via page for {Email}", email);
+            StatusMessage = "Something went wrong. Please try again later.";
+            IsSuccess = false;
+        }
+
+        return Page();
+    }
+}


### PR DESCRIPTION
## Summary

Newsletter subscription confirmations were broken because the  Razor page was referenced in confirmation emails but did not exist.

## Changes

- **Add ** — page model that validates the confirmation token against the  table and activates the subscription.
- **Add ** — corresponding Razor view with success/error UI.
- **Update ** —  now persists a  record to the DB with the confirmation token before sending the email, so the confirm link can be validated.

## Root Cause

 generated a confirmation link to  but the Razor page was never created. Users clicking the link in their email got a 404.

## Testing

- Subscribe via  → confirmation email sent with valid link
- Click confirmation link → subscription confirmed, success page shown
- Expired/invalid token → error message shown