### PR TITLE
Fix #Sitemap-NRE: NullReferenceException in sitemap when Author is null

### DIFF
--- a/src/Blog.Web/Pages/Sitemap.cshtml.cs
+++ b/src/Blog.Web/Pages/Sitemap.cshtml.cs
@@ -58,8 +58,11 @@ public class SitemapModel : PageModel
                 await WriteUrlAsync(writer, $"{siteUrl}/Tag/{tag.Slug}", DateTime.UtcNow, "weekly", "0.7");
             }
 
-            // Author profiles (get distinct authors)
-            var authors = posts.Select(p => p.Author).DistinctBy(a => a.Id);
+            // Author profiles (get distinct authors, filter null authors to avoid NRE)
+            var authors = posts
+                .Where(p => p.Author != null)
+                .Select(p => p.Author!)
+                .DistinctBy(a => a.Id);
             foreach (var author in authors)
             {
                 await WriteUrlAsync(writer, $"{siteUrl}/Author/{author.UserName}", DateTime.UtcNow, "weekly", "0.6");


### PR DESCRIPTION
## Summary
Sitemap.cshtml.cs calls `.Select(p => p.Author).DistinctBy(a => a.Id)` which throws a NullReferenceException if any post has a null Author (e.g., broken FK or deleted user).\n\n## Fix\nFilter out null authors with `.Where(p => p.Author != null).Select(p => p.Author!)` before applying DistinctBy.\n\n## Testing\n- [x] Code compiles cleanly\n- [ ] CI build passes