### PR TITLE
Fix #118: Validate post existence in EngagementService

### DIFF
--- a/src/Blog.Application/Services/EngagementService.cs
+++ b/src/Blog.Application/Services/EngagementService.cs
@@ -27,6 +27,10 @@ public class EngagementService : IEngagementService
 
     public async Task<bool> LikePostAsync(int postId, string userId, CancellationToken cancellationToken = default)
     {
+        var post = await _unitOfWork.Posts.GetByIdAsync(postId, cancellationToken);
+        if (post == null)
+            throw new InvalidOperationException($"Post with ID {postId} not found");
+
         if (await _unitOfWork.Likes.ExistsAsync(userId, postId, cancellationToken))
             return false;
 
@@ -53,6 +57,10 @@ public class EngagementService : IEngagementService
 
     public async Task<bool> BookmarkPostAsync(int postId, string userId, CancellationToken cancellationToken = default)
     {
+        var post = await _unitOfWork.Posts.GetByIdAsync(postId, cancellationToken);
+        if (post == null)
+            throw new InvalidOperationException($"Post with ID {postId} not found");
+
         if (await _unitOfWork.Bookmarks.ExistsAsync(userId, postId, cancellationToken))
             return false;
 


### PR DESCRIPTION
## Description\nFixes issue #118 - adds post existence validation in  and  to prevent creating orphaned like/bookmark records for non-existent posts.\n\n## Changes\n- Added post existence check in \n- Added post existence check in \n- Both methods now throw  when post doesn't exist, consistent with 