### PR TITLE
Fix #129: Encode user data in JSON-LD schema to prevent XSS

### DIFF
--- a/src/Blog.Web/Pages/Author/Profile.cshtml
+++ b/src/Blog.Web/Pages/Author/Profile.cshtml
@@ -1,5 +1,7 @@
 @page "/Author/{username}"
 @model Blog.Web.Pages.Author.ProfileModel
+@using System.Text.Encodings.Web
+
 @{
     ViewData["Title"] = Model.Profile?.DisplayName ?? "Author Not Found";
     ViewData["MetaDescription"] = Model.Profile != null
@@ -15,22 +17,22 @@
         {
             "@@context": "https://schema.org",
             "@@type": "Person",
-            "name": "@Model.Profile.DisplayName",
-            "url": "https://devof.net/Author/@Model.Profile.UserName",
-            "image": "@(Model.Profile.AvatarUrl ?? "https://devof.net/images/default-avatar.png")",
-            "description": "@(Model.Profile.Bio ?? $"{Model.Profile.DisplayName} is an author on Devof.NET")",
+            "name": "@JavaScriptEncoder.Default.Encode(Model.Profile.DisplayName)",
+            "url": "@JavaScriptEncoder.Default.Encode($"https://devof.net/Author/{Model.Profile.UserName}")",
+            "image": "@JavaScriptEncoder.Default.Encode(Model.Profile.AvatarUrl ?? "https://devof.net/images/default-avatar.png")",
+            "description": "@JavaScriptEncoder.Default.Encode(Model.Profile.Bio ?? $"{Model.Profile.DisplayName} is an author on Devof.NET")",
             "sameAs": [
         @if (!string.IsNullOrEmpty(Model.Profile.GitHubUrl))
         {
-            <text>"@Model.Profile.GitHubUrl"</text>
+            <text>"@JavaScriptEncoder.Default.Encode(Model.Profile.GitHubUrl)"</text>
         }
         @if (!string.IsNullOrEmpty(Model.Profile.TwitterUrl))
         {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) ? "," : "")@Html.Raw($"\"{Model.Profile.TwitterUrl}\"")</text>
+            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) ? "," : "")"@JavaScriptEncoder.Default.Encode(Model.Profile.TwitterUrl)"</text>
         }
         @if (!string.IsNullOrEmpty(Model.Profile.LinkedInUrl))
         {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) || !string.IsNullOrEmpty(Model.Profile.TwitterUrl) ? "," : "")@Html.Raw($"\"{Model.Profile.LinkedInUrl}\"")</text>
+            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) || !string.IsNullOrEmpty(Model.Profile.TwitterUrl) ? "," : "")"@JavaScriptEncoder.Default.Encode(Model.Profile.LinkedInUrl)"</text>
         }
         ]
     }

--- a/src/Blog.Web/Pages/Post/Details.cshtml
+++ b/src/Blog.Web/Pages/Post/Details.cshtml
@@ -1,5 +1,7 @@
 @page "/post/{slug}"
 @model Blog.Web.Pages.Post.DetailsModel
+@using System.Text.Encodings.Web
+
 @{
     ViewData["Title"] = Model.Post?.Title ?? "Post Not Found";
     ViewData["MetaDescription"] = Model.Post?.MetaDescription ?? Model.Post?.Excerpt;
@@ -22,13 +24,13 @@
                             {
                                 "@@context": "https://schema.org",
                                 "@@type": "Article",
-                                "headline": "@Model.Post.Title",
-                                "description": "@(Model.Post.MetaDescription ?? Model.Post.Excerpt)",
-                                "image": "@(Model.Post.CoverImageUrl ?? "https://devof.net/images/og-default.png")",
+                                "headline": "@JavaScriptEncoder.Default.Encode(Model.Post.Title)",
+                                "description": "@JavaScriptEncoder.Default.Encode(Model.Post.MetaDescription ?? Model.Post.Excerpt)",
+                                "image": "@JavaScriptEncoder.Default.Encode(Model.Post.CoverImageUrl ?? "https://devof.net/images/og-default.png")",
                                 "author": {
                                     "@@type": "Person",
-                                    "name": "@(Model.Post.Author.DisplayName ?? Model.Post.Author.UserName)",
-                                    "url": "https://devof.net/Author/@Model.Post.Author.UserName"
+                                    "name": "@JavaScriptEncoder.Default.Encode(Model.Post.Author.DisplayName ?? Model.Post.Author.UserName)",
+                                    "url": "@JavaScriptEncoder.Default.Encode($"https://devof.net/Author/{Model.Post.Author.UserName}")"
                                 },
                                 "publisher": {
                                     "@@type": "Organization",
@@ -42,9 +44,9 @@
                                 "dateModified": "@Model.Post.PublishedAt?.ToString("yyyy-MM-ddTHH:mm:ssZ")",
                                 "mainEntityOfPage": {
                                     "@@type": "WebPage",
-                                    "@@id": "https://devof.net/post/@Model.Post.Slug"
+                                    "@@id": "@JavaScriptEncoder.Default.Encode($"https://devof.net/post/{Model.Post.Slug}")"
                                 },
-                                "keywords": "@string.Join(", ", Model.Post.Tags.Select(t => t.Name))"
+                                "keywords": "@JavaScriptEncoder.Default.Encode(string.Join(", ", Model.Post.Tags.Select(t => t.Name)))"
                             }
                             </script>
 }


### PR DESCRIPTION
Fixes #129

## Summary

This PR fixes an XSS vulnerability where user-controlled data (post titles, author names, descriptions, tags, URLs) were directly embedded into JSON-LD `<script>` blocks without proper JSON escaping. An attacker with author-level access could inject script that executes in browsers.

## Changes

- Add `@using System.Text.Encodings.Web` to affected Razor pages
- Replace direct value embeddings with `JavaScriptEncoder.Default.Encode(...)`
- Affected pages:
  - `src/Blog.Web/Pages/Post/Details.cshtml` (Article schema)
  - `src/Blog.Web/Pages/Author/Profile.cshtml` (Person schema)

## Testing

- Locally verify pages render without errors
- Confirm JSON-LD schema is valid and values are properly escaped
- Check that no console errors appear

Closes #129