### PR TITLE
Fix #131: Escape user input in JSON-LD to prevent XSS

### DIFF
--- a/src/Blog.Web/Pages/Author/Profile.cshtml
+++ b/src/Blog.Web/Pages/Author/Profile.cshtml
@@ -8,29 +8,31 @@
     ViewData["OgImage"] = Model.Profile?.AvatarUrl ?? "https://devof.net/images/og-default.png";
 }
 
+@using System.Text.Json
+
 @if (Model.Profile != null)
 {
-        <!-- Person Schema for Author Rich Snippets -->
-        <script type="application/ld+json">
+    <!-- Person Schema for Author Rich Snippets -->
+    <script type="application/ld+json">
         {
             "@@context": "https://schema.org",
             "@@type": "Person",
-            "name": "@Model.Profile.DisplayName",
+            "name": @JsonSerializer.Serialize(Model.Profile.DisplayName),
             "url": "https://devof.net/Author/@Model.Profile.UserName",
-            "image": "@(Model.Profile.AvatarUrl ?? "https://devof.net/images/default-avatar.png")",
-            "description": "@(Model.Profile.Bio ?? $"{Model.Profile.DisplayName} is an author on Devof.NET")",
+            "image": @JsonSerializer.Serialize(Model.Profile.AvatarUrl ?? "https://devof.net/images/default-avatar.png"),
+            "description": @JsonSerializer.Serialize(Model.Profile.Bio ?? $"{Model.Profile.DisplayName} is an author on Devof.NET"),
             "sameAs": [
         @if (!string.IsNullOrEmpty(Model.Profile.GitHubUrl))
         {
-            <text>"@Model.Profile.GitHubUrl"</text>
+            <text>@JsonSerializer.Serialize(Model.Profile.GitHubUrl)</text>
         }
         @if (!string.IsNullOrEmpty(Model.Profile.TwitterUrl))
         {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) ? "," : "")@Html.Raw($"\"{Model.Profile.TwitterUrl}\"")</text>
+            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) ? "," : "")@JsonSerializer.Serialize(Model.Profile.TwitterUrl)</text>
         }
         @if (!string.IsNullOrEmpty(Model.Profile.LinkedInUrl))
         {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) || !string.IsNullOrEmpty(Model.Profile.TwitterUrl) ? "," : "")@Html.Raw($"\"{Model.Profile.LinkedInUrl}\"")</text>
+            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) || !string.IsNullOrEmpty(Model.Profile.TwitterUrl) ? "," : "")@JsonSerializer.Serialize(Model.Profile.LinkedInUrl)</text>
         }
         ]
     }

--- a/src/Blog.Web/Pages/Post/Details.cshtml
+++ b/src/Blog.Web/Pages/Post/Details.cshtml
@@ -1,19 +1,15 @@
 @page "/post/{slug}"
 @model Blog.Web.Pages.Post.DetailsModel
-@{
-    ViewData["Title"] = Model.Post?.Title ?? "Post Not Found";
-    ViewData["MetaDescription"] = Model.Post?.MetaDescription ?? Model.Post?.Excerpt;
-    ViewData["MetaKeywords"] = Model.Post?.MetaKeywords ?? (Model.Post != null ? string.Join(", ", Model.Post.Tags.Select(t
-    => t.Name)) : "");
-    ViewData["OgImage"] = Model.Post?.CoverImageUrl;
-    ViewData["OgType"] = "article";
-    ViewData["CanonicalUrl"] = $"https://devof.net/post/{Model.Post?.Slug}";
+@{ ViewData["Title"] = Model.Post?.Title ?? "Post Not Found"; ViewData["MetaDescription"] = Model.Post?.MetaDescription ?? Model.Post?.Excerpt; ViewData["MetaKeywords"] = Model.Post?.MetaKeywords ?? (Model.Post != null ? string.Join(", ", Model.Post.Tags.Select(t
+    => t.Name)) : ""); ViewData["OgImage"] = Model.Post?.CoverImageUrl; ViewData["OgType"] = "article"; ViewData["CanonicalUrl"] = $"https://devof.net/post/{Model.Post?.Slug}";
 
     var isAuthor = User.Identity?.IsAuthenticated == true &&
     (User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value == Model.Post?.Author.Id);
     var isAdmin = User.IsInRole("Admin");
     var canEdit = Model.CanEdit || User.IsInRole("Admin");
 }
+
+@using System.Text.Json
 
 @if (Model.Post != null)
 {
@@ -22,12 +18,12 @@
                             {
                                 "@@context": "https://schema.org",
                                 "@@type": "Article",
-                                "headline": "@Model.Post.Title",
-                                "description": "@(Model.Post.MetaDescription ?? Model.Post.Excerpt)",
-                                "image": "@(Model.Post.CoverImageUrl ?? "https://devof.net/images/og-default.png")",
+                                "headline": @JsonSerializer.Serialize(Model.Post.Title),
+                                "description": @JsonSerializer.Serialize(Model.Post.MetaDescription ?? Model.Post.Excerpt),
+                                "image": @JsonSerializer.Serialize(Model.Post.CoverImageUrl ?? "https://devof.net/images/og-default.png"),
                                 "author": {
                                     "@@type": "Person",
-                                    "name": "@(Model.Post.Author.DisplayName ?? Model.Post.Author.UserName)",
+                                    "name": @JsonSerializer.Serialize(Model.Post.Author.DisplayName ?? Model.Post.Author.UserName),
                                     "url": "https://devof.net/Author/@Model.Post.Author.UserName"
                                 },
                                 "publisher": {
@@ -44,7 +40,7 @@
                                     "@@type": "WebPage",
                                     "@@id": "https://devof.net/post/@Model.Post.Slug"
                                 },
-                                "keywords": "@string.Join(", ", Model.Post.Tags.Select(t => t.Name))"
+                                "keywords": @JsonSerializer.Serialize(string.Join(", ", Model.Post.Tags.Select(t => t.Name)))
                             }
                             </script>
 }


### PR DESCRIPTION
This fix addresses an XSS vulnerability where user-controlled data was directly embedded into JSON-LD script blocks without proper JSON escaping.

**Changes**
- Use `System.Text.Json.JsonSerializer.Serialize()` to properly escape all user-controlled values in JSON-LD structured data.

**Files changed**
- src/Blog.Web/Pages/Post/Details.cshtml
- src/Blog.Web/Pages/Author/Profile.cshtml

**Security impact**
Prevents JSON injection attacks that could break out of the JSON context and execute arbitrary JavaScript.

Fixes #131