### PR TITLE
Fix #131: Properly JSON-escape user input in JSON-LD to prevent XSS

### DIFF
--- a/src/Blog.Web/Pages/Author/Profile.cshtml
+++ b/src/Blog.Web/Pages/Author/Profile.cshtml
@@ -12,30 +12,9 @@
 
 @if (Model.Profile != null)
 {
-        <!-- Person Schema for Author Rich Snippets -->
-        <script type="application/ld+json">
-        {
-            "@@context": "https://schema.org",
-            "@@type": "Person",
-            "name": "@JavaScriptEncoder.Default.Encode(Model.Profile.DisplayName)",
-            "url": "@JavaScriptEncoder.Default.Encode($"https://devof.net/Author/{Model.Profile.UserName}")",
-            "image": "@JavaScriptEncoder.Default.Encode(Model.Profile.AvatarUrl ?? "https://devof.net/images/default-avatar.png")",
-            "description": "@JavaScriptEncoder.Default.Encode(Model.Profile.Bio ?? $"{Model.Profile.DisplayName} is an author on Devof.NET")",
-            "sameAs": [
-        @if (!string.IsNullOrEmpty(Model.Profile.GitHubUrl))
-        {
-            <text>"@JavaScriptEncoder.Default.Encode(Model.Profile.GitHubUrl)"</text>
-        }
-        @if (!string.IsNullOrEmpty(Model.Profile.TwitterUrl))
-        {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) ? "," : "")"@JavaScriptEncoder.Default.Encode(Model.Profile.TwitterUrl)"</text>
-        }
-        @if (!string.IsNullOrEmpty(Model.Profile.LinkedInUrl))
-        {
-            <text>@(!string.IsNullOrEmpty(Model.Profile.GitHubUrl) || !string.IsNullOrEmpty(Model.Profile.TwitterUrl) ? "," : "")"@JavaScriptEncoder.Default.Encode(Model.Profile.LinkedInUrl)"</text>
-        }
-        ]
-    }
+    <!-- Person Schema for Author Rich Snippets -->
+    <script type="application/ld+json">
+        @Html.Raw(Model.JsonLd)
     </script>
 }
 

--- a/src/Blog.Web/Pages/Author/Profile.cshtml.cs
+++ b/src/Blog.Web/Pages/Author/Profile.cshtml.cs
@@ -4,6 +4,8 @@ using Blog.Domain.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Security.Claims;
+using System.Text.Json;
+using System.Collections.Generic;
 
 namespace Blog.Web.Pages.Author;
 
@@ -25,6 +27,7 @@ public class ProfileModel : PageModel
 
     public AuthorProfileDto? Profile { get; set; }
     public PagedResult<PostDto> Posts { get; set; } = new();
+    public string JsonLd { get; private set; } = string.Empty;
 
     public async Task<IActionResult> OnGetAsync(string username, int page = 1)
     {
@@ -57,6 +60,23 @@ public class ProfileModel : PageModel
 
         Posts = await _postService.GetByAuthorAsync(user.Id, page, 9, Domain.Enums.PostStatus.Published, currentUserId);
         Profile.PostCount = Posts.TotalCount;
+
+        // Build JSON-LD with proper JSON escaping to prevent XSS
+        var jsonLdObj = new Dictionary<string, object?>
+        {
+            ["@context"] = "https://schema.org",
+            ["@type"] = "Person",
+            ["name"] = Profile.DisplayName,
+            ["url"] = $"https://devof.net/Author/{Profile.UserName}",
+            ["image"] = string.IsNullOrEmpty(Profile.AvatarUrl) ? "https://devof.net/images/default-avatar.png" : Profile.AvatarUrl,
+            ["description"] = string.IsNullOrEmpty(Profile.Bio) ? $"{Profile.DisplayName} is an author on Devof.NET" : Profile.Bio
+        };
+        var sameAs = new List<string?>();
+        if (!string.IsNullOrEmpty(Profile.GitHubUrl)) sameAs.Add(Profile.GitHubUrl);
+        if (!string.IsNullOrEmpty(Profile.TwitterUrl)) sameAs.Add(Profile.TwitterUrl);
+        if (!string.IsNullOrEmpty(Profile.LinkedInUrl)) sameAs.Add(Profile.LinkedInUrl);
+        if (sameAs.Count > 0) jsonLdObj["sameAs"] = sameAs;
+        JsonLd = JsonSerializer.Serialize(jsonLdObj);
 
         return Page();
     }

--- a/src/Blog.Web/Pages/Post/Details.cshtml
+++ b/src/Blog.Web/Pages/Post/Details.cshtml
@@ -21,34 +21,8 @@
 {
     <!-- Article Schema for Rich Snippets -->
     <script type="application/ld+json">
-                            {
-                                "@@context": "https://schema.org",
-                                "@@type": "Article",
-                                "headline": "@JavaScriptEncoder.Default.Encode(Model.Post.Title)",
-                                "description": "@JavaScriptEncoder.Default.Encode(Model.Post.MetaDescription ?? Model.Post.Excerpt)",
-                                "image": "@JavaScriptEncoder.Default.Encode(Model.Post.CoverImageUrl ?? "https://devof.net/images/og-default.png")",
-                                "author": {
-                                    "@@type": "Person",
-                                    "name": "@JavaScriptEncoder.Default.Encode(Model.Post.Author.DisplayName ?? Model.Post.Author.UserName)",
-                                    "url": "@JavaScriptEncoder.Default.Encode($"https://devof.net/Author/{Model.Post.Author.UserName}")"
-                                },
-                                "publisher": {
-                                    "@@type": "Organization",
-                                    "name": "Devof.NET",
-                                    "logo": {
-                                        "@@type": "ImageObject",
-                                        "url": "https://devof.net/images/logo.png"
-                                    }
-                                },
-                                "datePublished": "@Model.Post.PublishedAt?.ToString("yyyy-MM-ddTHH:mm:ssZ")",
-                                "dateModified": "@Model.Post.PublishedAt?.ToString("yyyy-MM-ddTHH:mm:ssZ")",
-                                "mainEntityOfPage": {
-                                    "@@type": "WebPage",
-                                    "@@id": "@JavaScriptEncoder.Default.Encode($"https://devof.net/post/{Model.Post.Slug}")"
-                                },
-                                "keywords": "@JavaScriptEncoder.Default.Encode(string.Join(", ", Model.Post.Tags.Select(t => t.Name)))"
-                            }
-                            </script>
+        @Html.Raw(Model.JsonLd)
+    </script>
 }
 
 @if (Model.Post == null)

--- a/src/Blog.Web/Pages/Post/Details.cshtml.cs
+++ b/src/Blog.Web/Pages/Post/Details.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using System.Security.Claims;
+using System.Text.Json;
 
 namespace Blog.Web.Pages.Post;
 
@@ -52,6 +53,7 @@ public class DetailsModel : PageModel
     public PostDetailDto? Post { get; set; }
     public PagedResult<CommentDto> Comments { get; set; } = new();
     public List<PostDto> RelatedPosts { get; set; } = new();
+    public string JsonLd { get; private set; } = string.Empty;
     
     // Authorization properties - calculated after Post is loaded
     public bool CanEdit => Post != null && User.Identity?.IsAuthenticated == true && IsCurrentUserAuthor();
@@ -88,7 +90,50 @@ public class DetailsModel : PageModel
         Comments = await _commentService.GetByPostIdAsync(Post.Id, page);
         RelatedPosts = await _postService.GetRelatedAsync(Post.Id, 3, userId);
 
+        // Build JSON-LD with proper JSON escaping to prevent XSS
+        JsonLd = BuildJsonLd();
+
         return Page();
+    }
+
+    private string BuildJsonLd()
+    {
+        if (Post == null) return string.Empty;
+
+        var jsonLd = new Dictionary<string, object?>
+        {
+            ["@context"] = "https://schema.org",
+            ["@type"] = "Article",
+            ["headline"] = Post.Title,
+            ["description"] = Post.MetaDescription ?? Post.Excerpt,
+            ["image"] = string.IsNullOrEmpty(Post.CoverImageUrl) ? "https://devof.net/images/og-default.png" : Post.CoverImageUrl,
+            ["author"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "Person",
+                ["name"] = Post.Author.DisplayName ?? Post.Author.UserName,
+                ["url"] = $"https://devof.net/Author/{Post.Author.UserName}"
+            },
+            ["publisher"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "Organization",
+                ["name"] = "Devof.NET",
+                ["logo"] = new Dictionary<string, object?>
+                {
+                    ["@type"] = "ImageObject",
+                    ["url"] = "https://devof.net/images/logo.png"
+                }
+            },
+            ["datePublished"] = Post.PublishedAt?.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+            ["dateModified"] = Post.PublishedAt?.ToString("yyyy-MM-ddTHH:mm:ssZ"),
+            ["mainEntityOfPage"] = new Dictionary<string, object?>
+            {
+                ["@type"] = "WebPage",
+                ["@id"] = $"https://devof.net/post/{Post.Slug}"
+            },
+            ["keywords"] = string.Join(", ", Post.Tags.Select(t => t.Name))
+        };
+
+        return JsonSerializer.Serialize(jsonLd);
     }
 
     public async Task<IActionResult> OnPostLikeAsync(string slug)


### PR DESCRIPTION
Fixes #131 by using System.Text.Json.JsonSerializer to safely serialize JSON-LD data in the server-side PageModel, eliminating XSS risk from unescaped user input. Changes made to Details.cshtml, Details.cshtml.cs, Profile.cshtml, Profile.cshtml.cs.