### PR TITLE
Fix: EngagementService.GetBookmarkedPostsAsync properly sets IsLiked property

### DIFF
--- a/src/Blog.Application/Services/EngagementService.cs
+++ b/src/Blog.Application/Services/EngagementService.cs
@@ -89,10 +89,19 @@ public class EngagementService : IEngagementService
     {
         var bookmarks = await _unitOfWork.Bookmarks.GetByUserIdAsync(userId, page, pageSize, cancellationToken);
         var totalCount = await _unitOfWork.Bookmarks.GetCountByUserIdAsync(userId, cancellationToken);
-        
+
+        var items = new List<PostDto>();
+        foreach (var bookmark in bookmarks)
+        {
+            if (bookmark.Post != null)
+            {
+                items.Add(await MapPostToDtoAsync(bookmark.Post, userId, cancellationToken));
+            }
+        }
+
         return new PagedResult<PostDto>
         {
-            Items = bookmarks.Select(b => MapPostToDto(b.Post, userId)).ToList(),
+            Items = items,
             Page = page,
             PageSize = pageSize,
             TotalCount = totalCount
@@ -133,8 +142,10 @@ public class EngagementService : IEngagementService
         return await _unitOfWork.Follows.IsFollowingAsync(followerId, followingId, cancellationToken);
     }
 
-    private static PostDto MapPostToDto(Post post, string userId)
+    private async Task<PostDto> MapPostToDtoAsync(Post post, string userId, CancellationToken cancellationToken)
     {
+        var isLiked = await _unitOfWork.Likes.ExistsAsync(userId, post.Id, cancellationToken);
+
         return new PostDto
         {
             Id = post.Id,
@@ -150,7 +161,8 @@ public class EngagementService : IEngagementService
             LikeCount = post.Likes?.Count ?? 0,
             CommentCount = post.Comments?.Count ?? 0,
             BookmarkCount = post.Bookmarks?.Count ?? 0,
-            IsBookmarked = true, // Since we're getting bookmarked posts
+            IsLiked = isLiked,
+            IsBookmarked = true,
             Author = post.Author != null ? new UserDto
             {
                 Id = post.Author.Id,


### PR DESCRIPTION
### What was the issue?
When viewing bookmarked posts via GetBookmarkedPostsAsync, the IsLiked property was not being calculated, leaving it as false/default for all bookmarked posts.

### Root cause
The PR #130 simplified MapPostToDto to a static method and removed the async IsLiked calculation when fetching bookmarked posts. This meant bookmarked posts were returned with IsLiked = false regardless of the user's actual like status.

### Fix
- Reintroduces async MapPostToDtoAsync that properly calculates IsLiked by querying the Likes repository
- Updates GetBookmarkedPostsAsync to use the async map method
- Ensures each bookmarked post has the correct IsLiked status

### Build
✅ Build: Success (0 warnings, 0 errors)

Fixes issue with bookmarked post like status not being calculated.